### PR TITLE
Cife e internacionalización

### DIFF
--- a/directivos.html
+++ b/directivos.html
@@ -162,10 +162,6 @@
             <td>Juny Montoya</td>
         </tr>
         <tr>
-            <td>Centro de Investigación <br /> y Formación en Educación (Cife)</td>
-            <td>Eduardo Escallón</td>
-        </tr>
-        <tr>
             <td>
                 <p>Centro Interdisciplinario <br /> de Estudios sobre Desarrollo (Cider)</p>
             </td>
@@ -449,6 +445,11 @@
             </td>
         </tr>
         <tr>
+          <td>Centro de Investigación <br />
+            y Formación en Educación (Cife)</td>
+          <td>Eduardo Escallón</td>
+        </tr>
+        <tr>
             <td colspan="3">
                 <p>&nbsp;</p>
             </td>
@@ -495,6 +496,10 @@
         <tr>
             <td valign="top">Dirección de Gestión y Desarrollo Académico</td>
             <td valign="top">Francisco Zarur</td>
+        </tr>
+        <tr>
+          <td valign="top">Dirección de Internacionalización</td>
+          <td valign="top">Carolyn Finck</td>
         </tr>
         <tr>
             <td valign="top">Dirección de Investigación y Doctorados</td>


### PR DESCRIPTION
Cife pasa a centros, como el Cede.
Entra Dirección de Internacionalización a Servicios de Apoyo, Carolyn
Finck.
